### PR TITLE
chore: add types declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'gst-states' {
+  const value: any;
+  export default value;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "description": "India GST state codes",
   "main": "index.json",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo no-test",
     "lint": "run-s lint:prettier:check",


### PR DESCRIPTION
as importing the module in a type script module leads to a complaint from typescript about
declaration not found
